### PR TITLE
Photos measure soil height mingyu (Part 2)

### DIFF
--- a/frontend/demo/demo_support_framework/supports.ts
+++ b/frontend/demo/demo_support_framework/supports.ts
@@ -31,8 +31,8 @@ export const demoImages: TaggedImage[] = [
 			"created_at": "2017-06-03T14:15:50.666Z",
 			"attachment_url": "https://i.imgur.com/LLajqT3.jpeg",
 			"meta": {
-				"x": 150,
-				"y": 100,
+				"x": 200,
+				"y": 200,
 				"z": 164
 			}
 		},
@@ -47,10 +47,10 @@ export const demoImages: TaggedImage[] = [
 			"attachment_processed_at": "2017-06-02T14:16:45.899Z",
 			"updated_at": "2017-06-02T14:16:45.903Z",
 			"created_at": "2017-06-02T14:14:22.747Z",
-			"attachment_url": "https://i.imgur.com/jgZMupJ.jpeg",
+			"attachment_url": "https://i.imgur.com/EVo6XOU.jpeg",
 			"meta": {
-				"x": 150,
-				"y": 500,
+				"x": 200,
+				"y": 600,
 				"z": 164
 			}
 		},
@@ -67,8 +67,8 @@ export const demoImages: TaggedImage[] = [
 			"created_at": "2017-06-01T14:14:22.726Z",
 			"attachment_url": "https://i.imgur.com/WsqcMr3.jpeg",
 			"meta": {
-				"x": 150,
-				"y": 900,
+				"x": 200,
+				"y": 1000,
 				"z": 53
 			}
 		},
@@ -85,8 +85,8 @@ export const demoImages: TaggedImage[] = [
 			"created_at": "2017-05-28T14:15:50.666Z",
 			"attachment_url": "https://i.imgur.com/EudVDLU.jpeg",
 			"meta": {
-				"x": 550,
-				"y": 100,
+				"x": 600,
+				"y": 200,
 				"z": 164
 			}
 		},
@@ -103,8 +103,8 @@ export const demoImages: TaggedImage[] = [
 			"created_at": "2017-05-27T14:15:50.666Z",
 			"attachment_url": "https://i.imgur.com/Xou4Ubz.jpeg",
 			"meta": {
-				"x": 550,
-				"y": 500,
+				"x": 600,
+				"y": 600,
 				"z": 164
 			}
 		},
@@ -121,8 +121,8 @@ export const demoImages: TaggedImage[] = [
 			"created_at": "2017-05-26T14:15:50.666Z",
 			"attachment_url": "https://i.imgur.com/kAmrAZy.jpeg",
 			"meta": {
-				"x": 550,
-				"y": 900,
+				"x": 600,
+				"y": 1000,
 				"z": 164
 			}
 		},
@@ -139,8 +139,8 @@ export const demoImages: TaggedImage[] = [
 			"created_at": "2017-05-25T14:15:50.666Z",
 			"attachment_url": "https://i.imgur.com/emxArQX.jpeg",
 			"meta": {
-				"x": 950,
-				"y": 100,
+				"x": 1000,
+				"y": 200,
 				"z": 164
 			}
 		},
@@ -157,8 +157,8 @@ export const demoImages: TaggedImage[] = [
 			"created_at": "2017-05-21T14:15:50.666Z",
 			"attachment_url": "https://i.imgur.com/U3mBYpG.jpeg",
 			"meta": {
-				"x": 950,
-				"y": 500,
+				"x": 1000,
+				"y": 600,
 				"z": 164
 			}
 		},
@@ -173,10 +173,10 @@ export const demoImages: TaggedImage[] = [
 			"attachment_processed_at": "2017-05-20T14:16:55.709Z",
 			"updated_at": "2017-05-20T14:16:55.715Z",
 			"created_at": "2017-05-20T14:15:50.666Z",
-			"attachment_url": "https://i.imgur.com/EVo6XOU.jpeg",
+			"attachment_url": "https://i.imgur.com/jgZMupJ.jpeg",
 			"meta": {
-				"x": 950,
-				"y": 900,
+				"x": 1000,
+				"y": 1000,
 				"z": 164
 			}
 		},

--- a/frontend/demo/demo_support_framework/supports.ts
+++ b/frontend/demo/demo_support_framework/supports.ts
@@ -3,6 +3,7 @@ import {
 	TaggedImage,
 	Xyz,
 } from "farmbot";
+import cloneDeep from 'lodash/cloneDeep';
 
 // a local representation of the current status of position
 export const demoPos: Record<Xyz, number | undefined> = {
@@ -183,59 +184,13 @@ export const demoImages: TaggedImage[] = [
 	},
 ];
 
-export const flipperImages: TaggedImage[] = [
-	{
-		"kind": "Image",
-		"specialStatus": SpecialStatus.SAVED,
-		"body": {
-			"id": 7,
-			"device_id": 8,
-			"attachment_processed_at": "2017-05-25T14:16:55.709Z",
-			"updated_at": "2017-05-25T14:16:55.715Z",
-			"created_at": "2017-05-25T14:15:50.666Z",
-			"attachment_url": "https://i.imgur.com/emxArQX.jpeg",
-			"meta": {
-				"x": 950,
-				"y": 100,
-				"z": 164
-			}
-		},
-		"uuid": "Image.6.6"
-	},
-	{
-		"kind": "Image",
-		"specialStatus": SpecialStatus.SAVED,
-		"body": {
-			"id": 8,
-			"device_id": 8,
-			"attachment_processed_at": "2017-05-21T14:16:55.709Z",
-			"updated_at": "2017-05-21T14:16:55.715Z",
-			"created_at": "2017-05-21T14:15:50.666Z",
-			"attachment_url": "https://i.imgur.com/U3mBYpG.jpeg",
-			"meta": {
-				"x": 950,
-				"y": 500,
-				"z": 164
-			}
-		},
-		"uuid": "Image.6.5"
-	},
-	{
-		"kind": "Image",
-		"specialStatus": SpecialStatus.SAVED,
-		"body": {
-			"id": 9,
-			"device_id": 8,
-			"attachment_processed_at": "2017-05-20T14:16:55.709Z",
-			"updated_at": "2017-05-20T14:16:55.715Z",
-			"created_at": "2017-05-20T14:15:50.666Z",
-			"attachment_url": "https://i.imgur.com/EVo6XOU.jpeg",
-			"meta": {
-				"x": 950,
-				"y": 900,
-				"z": 164
-			}
-		},
-		"uuid": "Image.6.4"
-	},
-]
+export var prevImages = cloneDeep(demoImages);
+
+export function checkUpdate() {
+	if (prevImages.length != demoImages.length) {
+		prevImages = cloneDeep(demoImages);
+		return true;
+	} else {
+		return false;
+	}
+}

--- a/frontend/photos/images/image_flipper.tsx
+++ b/frontend/photos/images/image_flipper.tsx
@@ -93,7 +93,6 @@ export class ImageFlipper extends
 				images:demoImages, 
 				currentImage: demoImages[0]
 			})
-			console.log("updated!"); 
 		} 
     return <div className={`image-flipper ${this.props.id}`} id={this.props.id}
       onKeyDown={e => {

--- a/frontend/photos/images/image_flipper.tsx
+++ b/frontend/photos/images/image_flipper.tsx
@@ -8,7 +8,7 @@ import { FlipperImage } from "./flipper_image";
 import { selectImage, setShownMapImages } from "./actions";
 import { TaggedImage } from "farmbot";
 import { UUID } from "../../resources/interfaces";
-import { flipperImages } from "../../demo/demo_support_framework/supports";
+import { demoImages, checkUpdate } from "../../demo/demo_support_framework/supports";
 
 export const PLACEHOLDER_FARMBOT = "/placeholder_farmbot.jpg";
 export const PLACEHOLDER_FARMBOT_DARK = "/placeholder_farmbot_dark.jpg";
@@ -46,8 +46,8 @@ export const PlaceholderImg = (props: PlaceholderImgProps) =>
 
 export class ImageFlipper extends
   React.Component<ImageFlipperProps, ImageFlipperState> {
-  state: ImageFlipperState = { disableNext: false, disablePrev: true, images: flipperImages,
-	currentImage: flipperImages[0]};
+  state: ImageFlipperState = { disableNext: false, disablePrev: true, images: demoImages,
+	currentImage: demoImages[0]};
 
   onImageLoad = (img: HTMLImageElement) => {
     this.props.dispatch({
@@ -69,17 +69,17 @@ export class ImageFlipper extends
     //     ? this.props.flipActionOverride(nextIndex)
     //     : this.props.dispatch(selectNextImage(this.props.images, nextIndex));
     // }
-    const nextIndex = flipperImages.indexOf(this.state.currentImage) + increment; 
-	const indexAfterNext = flipperImages.indexOf(this.state.currentImage) + 2 * increment; 
-	const tooHigh = (index: number): boolean => index > flipperImages.length - 1;
+    const nextIndex = demoImages.indexOf(this.state.currentImage) + increment; 
+	const indexAfterNext = demoImages.indexOf(this.state.currentImage) + 2 * increment; 
+	const tooHigh = (index: number): boolean => index > demoImages.length - 1;
     const tooLow = (index: number): boolean => index < 0;
 
 	if (!tooHigh(nextIndex) && !tooLow(nextIndex)) {
 		this.setState({
 			disableNext: tooHigh(indexAfterNext),
 			disablePrev: tooLow(indexAfterNext),
-			images: flipperImages,
-			currentImage: flipperImages[nextIndex]
+			images: demoImages,
+			currentImage: demoImages[nextIndex]
 		});
 	}
   };
@@ -88,6 +88,13 @@ export class ImageFlipper extends
 	const { images, currentImage } = forceOnline() ? this.state: this.props; 
     const multipleImages = images.length > 1;
     const dark = this.props.id === "fullscreen-flipper";
+		if (checkUpdate()) {
+			this.setState({
+				images:demoImages, 
+				currentImage: demoImages[0]
+			})
+			console.log("updated!"); 
+		} 
     return <div className={`image-flipper ${this.props.id}`} id={this.props.id}
       onKeyDown={e => {
         if (["ArrowLeft", "ArrowRight"].includes(e.key)) {

--- a/frontend/photos/photos.tsx
+++ b/frontend/photos/photos.tsx
@@ -32,8 +32,10 @@ import { DevSettings } from "../settings/dev/dev_support";
 import { forceOnline } from "../devices/must_be_online";
 import { initSave } from "../api/crud";
 import { moveMeasureDemo } from "../devices/actions";
-import { demoPos } from "../demo/demo_support_framework/supports";
+import { demoPos, demoImages } from "../demo/demo_support_framework/supports";
 import {GenericPointer } from "farmbot/dist/resources/api_resources";
+import {Xyz} from "farmbot";
+import cloneDeep from 'lodash/cloneDeep';
 
 export class RawDesignerPhotos
   extends React.Component<DesignerPhotosProps> {
@@ -56,6 +58,7 @@ export class RawDesignerPhotos
 	handleMeasure = () => {
 		moveMeasureDemo(10); 
 		setTimeout(()=>moveMeasureDemo(-10), 2000); 
+		setTimeout(()=>demoImages.unshift(cloneDeep(demoImages[this.retrieveIndexOfPhoto(demoPos)])), 2000); 
 		const body: GenericPointer = {
 			pointer_type: "GenericPointer",
 			name: "SoilHeight Point",
@@ -71,6 +74,11 @@ export class RawDesignerPhotos
 			radius: 100,
 		};
 		setTimeout(() => this.props.dispatch(initSave("Point", body)), 2000);
+	 }
+
+	 retrieveIndexOfPhoto = (pos: Record<Xyz, number | undefined>) => {
+		const id: number = Math.floor(((pos.x||0)+150)/400) * 3 + Math.floor(((pos.y||0)+100)/400) + 1; 
+    return demoImages.indexOf(demoImages.filter(i => i.body.id === id)[0])
 	 }
 
   render() {

--- a/frontend/photos/photos.tsx
+++ b/frontend/photos/photos.tsx
@@ -59,6 +59,7 @@ export class RawDesignerPhotos
 		moveMeasureDemo(10); 
 		setTimeout(()=>moveMeasureDemo(-10), 2000); 
 		setTimeout(()=>demoImages.unshift(cloneDeep(demoImages[this.retrieveIndexOfPhoto(demoPos)])), 2000); 
+		const imageZ: number = demoImages[0].body.meta.z || 0; 
 		const body: GenericPointer = {
 			pointer_type: "GenericPointer",
 			name: "SoilHeight Point",
@@ -70,7 +71,7 @@ export class RawDesignerPhotos
 			},
 			x: demoPos.x || 0,
 			y: demoPos.y || 0,
-			z: demoPos.z || 0,
+			z: demoPos.z || 0 - imageZ,
 			radius: 100,
 		};
 		setTimeout(() => this.props.dispatch(initSave("Point", body)), 2000);


### PR DESCRIPTION
Implement soil height measurement & photo uploading when measuring. 

Soil height measurement: 
1. Take images of the current position. 
2. Process the image to get the soil height. 
3. Create a soil height point according to the soil height. 
4. Dispatch the action: initSave to save the point. 
5. Soil height successfully shows on the map. 

Photo processing and uploading: 
1. Take images of the current position. 
2. Process the image and push the processed image at the head of demoImages. 
3. ImageFlipper check if the state of images is changed and update. (add an array of images to record the previous state of demoImages, if previous state is different from the current, then update). 
