### PR TITLE
take photo button logic implemented

### DIFF
--- a/frontend/controls/move/take_photo_button.tsx
+++ b/frontend/controls/move/take_photo_button.tsx
@@ -6,6 +6,9 @@ import { cameraBtnProps } from "../../photos/capture_settings/camera_selection";
 import { Popover } from "../../ui";
 import { greaterThanTime, recentMsgLog } from "../../wizard/checks";
 import { TakePhotoButtonProps } from "./interfaces";
+import { forceOnline } from "../../devices/must_be_online";
+import { demoImages, getImage } from "../../demo/demo_support_framework/supports";
+import { cloneDeep } from "lodash";
 
 interface TakePhotoButtonState {
   clickedAt: number | undefined;
@@ -43,7 +46,9 @@ export class TakePhotoButton
         camDisabled.class,
       ].join(" ")}
       title={camDisabled.title || t("Take a photo")}
-      onClick={camDisabled.click || sendCommand}>
+      onClick={() => forceOnline() 
+				? demoImages.unshift(cloneDeep(getImage()))
+				: camDisabled.click || sendCommand}>
       {!botOnline &&
         <Popover
           popoverClassName={"help camera-message"}

--- a/frontend/demo/demo_support_framework/supports.ts
+++ b/frontend/demo/demo_support_framework/supports.ts
@@ -184,6 +184,11 @@ export const demoImages: TaggedImage[] = [
 	},
 ];
 
+export function getImage(): TaggedImage {
+	const id: number = Math.floor(((demoPos.x || 0) + 150) / 400) * 3 + Math.floor(((demoPos.y || 0) + 100) / 400) + 1;
+	return demoImages[demoImages.indexOf(demoImages.filter(i => i.body.id === id)[0])]
+}
+
 export var prevImages = cloneDeep(demoImages);
 
 export function checkUpdate() {

--- a/frontend/photos/photos.tsx
+++ b/frontend/photos/photos.tsx
@@ -32,9 +32,8 @@ import { DevSettings } from "../settings/dev/dev_support";
 import { forceOnline } from "../devices/must_be_online";
 import { initSave } from "../api/crud";
 import { moveMeasureDemo } from "../devices/actions";
-import { demoPos, demoImages } from "../demo/demo_support_framework/supports";
+import { demoPos, demoImages, getImage } from "../demo/demo_support_framework/supports";
 import {GenericPointer } from "farmbot/dist/resources/api_resources";
-import {Xyz} from "farmbot";
 import cloneDeep from 'lodash/cloneDeep';
 
 export class RawDesignerPhotos
@@ -58,7 +57,7 @@ export class RawDesignerPhotos
 	handleMeasure = () => {
 		moveMeasureDemo(10); 
 		setTimeout(()=>moveMeasureDemo(-10), 2000); 
-		setTimeout(()=>demoImages.unshift(cloneDeep(demoImages[this.retrieveIndexOfPhoto(demoPos)])), 2000); 
+		setTimeout(()=>demoImages.unshift(cloneDeep(getImage())), 2000); 
 		const imageZ: number = demoImages[0].body.meta.z || 0; 
 		const body: GenericPointer = {
 			pointer_type: "GenericPointer",
@@ -75,11 +74,6 @@ export class RawDesignerPhotos
 			radius: 100,
 		};
 		setTimeout(() => this.props.dispatch(initSave("Point", body)), 2000);
-	 }
-
-	 retrieveIndexOfPhoto = (pos: Record<Xyz, number | undefined>) => {
-		const id: number = Math.floor(((pos.x||0)+150)/400) * 3 + Math.floor(((pos.y||0)+100)/400) + 1; 
-    return demoImages.indexOf(demoImages.filter(i => i.body.id === id)[0])
 	 }
 
   render() {


### PR DESCRIPTION
When clicking the camera button on 'MOVE' tab, a photo will be taken and added to photo flipper. 

Create an event handler which takes a photo and pushes it at the head of photo array for the event: click 'camera' button. Taking photo is successfully implemented. 