### PR TITLE
Photos-compare photos-mingyu

### DIFF
--- a/frontend/demo/demo_support_framework/demo_photos.ts
+++ b/frontend/demo/demo_support_framework/demo_photos.ts
@@ -1,0 +1,188 @@
+import {
+	SpecialStatus,
+	TaggedImage,
+} from "farmbot";
+
+// a sample of images for demo
+export const demoPhotos: TaggedImage[] = [
+	{
+		"kind": "Image",
+		"specialStatus": SpecialStatus.SAVED,
+		"body": {
+			"id": 1,
+			"device_id": 8,
+			"attachment_processed_at": "2017-06-03T14:16:55.709Z",
+			"updated_at": "2017-06-03T14:16:55.715Z",
+			"created_at": "2017-06-03T14:15:50.666Z",
+			"attachment_url": "https://i.imgur.com/LLajqT3.jpeg",
+			"meta": {
+				"x": 200,
+				"y": 200,
+				"z": 164
+			}
+		},
+		"uuid": "Image.9.3"
+	},
+	{
+		"kind": "Image",
+		"specialStatus": SpecialStatus.SAVED,
+		"body": {
+			"id": 10,
+			"device_id": 8,
+			"attachment_processed_at": "2017-06-03T14:16:54.709Z",
+			"updated_at": "2017-06-03T14:16:54.715Z",
+			"created_at": "2017-06-03T14:15:49.666Z",
+			"attachment_url": "https://i.imgur.com/jgZMupJ.jpeg",
+			"meta": {
+				"x": 200,
+				"y": 200,
+				"z": 164
+			}
+		},
+		"uuid": "Image.9.2"
+	},
+	{
+		"kind": "Image",
+		"specialStatus": SpecialStatus.SAVED,
+		"body": {
+			"id": 2,
+			"device_id": 8,
+			"attachment_processed_at": "2017-06-02T14:16:45.899Z",
+			"updated_at": "2017-06-02T14:16:45.903Z",
+			"created_at": "2017-06-02T14:14:22.747Z",
+			"attachment_url": "https://i.imgur.com/EVo6XOU.jpeg",
+			"meta": {
+				"x": 200,
+				"y": 600,
+				"z": 164
+			}
+		},
+		"uuid": "Image.8.4"
+	},
+	{
+		"kind": "Image",
+		"specialStatus": SpecialStatus.SAVED,
+		"body": {
+			"id": 3,
+			"device_id": 8,
+			"attachment_processed_at": "2017-06-01T14:16:34.839Z",
+			"updated_at": "2017-06-01T14:16:34.984Z",
+			"created_at": "2017-06-01T14:14:22.726Z",
+			"attachment_url": "https://i.imgur.com/WsqcMr3.jpeg",
+			"meta": {
+				"x": 200,
+				"y": 1000,
+				"z": 53
+			}
+		},
+		"uuid": "Image.7.5"
+	},
+	{
+		"kind": "Image",
+		"specialStatus": SpecialStatus.SAVED,
+		"body": {
+			"id": 4,
+			"device_id": 8,
+			"attachment_processed_at": "2017-05-28T14:16:55.709Z",
+			"updated_at": "2017-05-28T14:16:55.715Z",
+			"created_at": "2017-05-28T14:15:50.666Z",
+			"attachment_url": "https://i.imgur.com/EudVDLU.jpeg",
+			"meta": {
+				"x": 600,
+				"y": 200,
+				"z": 164
+			}
+		},
+		"uuid": "Image.6.9"
+	},
+	{
+		"kind": "Image",
+		"specialStatus": SpecialStatus.SAVED,
+		"body": {
+			"id": 5,
+			"device_id": 8,
+			"attachment_processed_at": "2017-05-27T14:16:55.709Z",
+			"updated_at": "2017-05-27T14:16:55.715Z",
+			"created_at": "2017-05-27T14:15:50.666Z",
+			"attachment_url": "https://i.imgur.com/Xou4Ubz.jpeg",
+			"meta": {
+				"x": 600,
+				"y": 600,
+				"z": 164
+			}
+		},
+		"uuid": "Image.6.8"
+	},
+	{
+		"kind": "Image",
+		"specialStatus": SpecialStatus.SAVED,
+		"body": {
+			"id": 6,
+			"device_id": 8,
+			"attachment_processed_at": "2017-05-26T14:16:55.709Z",
+			"updated_at": "2017-05-26T14:16:55.715Z",
+			"created_at": "2017-05-26T14:15:50.666Z",
+			"attachment_url": "https://i.imgur.com/kAmrAZy.jpeg",
+			"meta": {
+				"x": 600,
+				"y": 1000,
+				"z": 164
+			}
+		},
+		"uuid": "Image.6.7"
+	},
+	{
+		"kind": "Image",
+		"specialStatus": SpecialStatus.SAVED,
+		"body": {
+			"id": 7,
+			"device_id": 8,
+			"attachment_processed_at": "2017-05-25T14:16:55.709Z",
+			"updated_at": "2017-05-25T14:16:55.715Z",
+			"created_at": "2017-05-25T14:15:50.666Z",
+			"attachment_url": "https://i.imgur.com/emxArQX.jpeg",
+			"meta": {
+				"x": 1000,
+				"y": 200,
+				"z": 164
+			}
+		},
+		"uuid": "Image.6.6"
+	},
+	{
+		"kind": "Image",
+		"specialStatus": SpecialStatus.SAVED,
+		"body": {
+			"id": 8,
+			"device_id": 8,
+			"attachment_processed_at": "2017-05-21T14:16:55.709Z",
+			"updated_at": "2017-05-21T14:16:55.715Z",
+			"created_at": "2017-05-21T14:15:50.666Z",
+			"attachment_url": "https://i.imgur.com/U3mBYpG.jpeg",
+			"meta": {
+				"x": 1000,
+				"y": 600,
+				"z": 164
+			}
+		},
+		"uuid": "Image.6.5"
+	},
+	{
+		"kind": "Image",
+		"specialStatus": SpecialStatus.SAVED,
+		"body": {
+			"id": 9,
+			"device_id": 8,
+			"attachment_processed_at": "2017-05-20T14:16:55.709Z",
+			"updated_at": "2017-05-20T14:16:55.715Z",
+			"created_at": "2017-05-20T14:15:50.666Z",
+			"attachment_url": "https://i.imgur.com/jgZMupJ.jpeg",
+			"meta": {
+				"x": 1000,
+				"y": 1000,
+				"z": 164
+			}
+		},
+		"uuid": "Image.6.4"
+	},
+];

--- a/frontend/demo/demo_support_framework/demo_photos.ts
+++ b/frontend/demo/demo_support_framework/demo_photos.ts
@@ -27,24 +27,6 @@ export const demoPhotos: TaggedImage[] = [
 		"kind": "Image",
 		"specialStatus": SpecialStatus.SAVED,
 		"body": {
-			"id": 10,
-			"device_id": 8,
-			"attachment_processed_at": "2017-06-03T14:16:54.709Z",
-			"updated_at": "2017-06-03T14:16:54.715Z",
-			"created_at": "2017-06-03T14:15:49.666Z",
-			"attachment_url": "https://i.imgur.com/jgZMupJ.jpeg",
-			"meta": {
-				"x": 200,
-				"y": 200,
-				"z": 164
-			}
-		},
-		"uuid": "Image.9.2"
-	},
-	{
-		"kind": "Image",
-		"specialStatus": SpecialStatus.SAVED,
-		"body": {
 			"id": 2,
 			"device_id": 8,
 			"attachment_processed_at": "2017-06-02T14:16:45.899Z",
@@ -184,5 +166,23 @@ export const demoPhotos: TaggedImage[] = [
 			}
 		},
 		"uuid": "Image.6.4"
+	},
+	{
+		"kind": "Image",
+		"specialStatus": SpecialStatus.SAVED,
+		"body": {
+			"id": 10,
+			"device_id": 8,
+			"attachment_processed_at": "2017-06-03T14:16:54.709Z",
+			"updated_at": "2017-06-03T14:16:54.715Z",
+			"created_at": "2017-06-03T14:15:49.666Z",
+			"attachment_url": "https://i.imgur.com/Xou4Ubz.jpeg",
+			"meta": {
+				"x": 200,
+				"y": 200,
+				"z": 164
+			}
+		},
+		"uuid": "Image.9.2"
 	},
 ];

--- a/frontend/demo/demo_support_framework/supports.ts
+++ b/frontend/demo/demo_support_framework/supports.ts
@@ -251,3 +251,12 @@ export function checkUpdate() {
 	}
 }
 
+export const demoRenderLabel = (value: number) => {
+	if (value == demoImages.length - 1) { return t("newest"); }
+	if (value == 0) { return t("oldest"); }
+	return "";
+}
+export const demoGetImageIndex = (image: TaggedImage | undefined): number => {
+	if (image) { return demoImages.length - 1 - demoImages.indexOf(image) }
+	else { return 0 }
+}

--- a/frontend/demo/demo_support_framework/supports.ts
+++ b/frontend/demo/demo_support_framework/supports.ts
@@ -38,46 +38,6 @@ export const map_limit = {
 // a sample of images for demo
 export var demoImages: TaggedImage[] = demoPhotos;
 
-// place holder for compare Images
-export var compareImages: TaggedImage[] = [
-	{
-		"kind": "Image",
-		"specialStatus": SpecialStatus.SAVED,
-		"body": {
-			"id": 1,
-			"device_id": 8,
-			"attachment_processed_at": "2017-06-03T14:16:55.709Z",
-			"updated_at": "2017-06-03T14:16:55.715Z",
-			"created_at": "2017-06-03T14:15:50.666Z",
-			"attachment_url": "https://i.imgur.com/LLajqT3.jpeg",
-			"meta": {
-				"x": 200,
-				"y": 200,
-				"z": 164
-			}
-		},
-		"uuid": "Image.9.3"
-	},
-	{
-		"kind": "Image",
-		"specialStatus": SpecialStatus.SAVED,
-		"body": {
-			"id": 10,
-			"device_id": 8,
-			"attachment_processed_at": "2017-06-03T14:16:54.709Z",
-			"updated_at": "2017-06-03T14:16:54.715Z",
-			"created_at": "2017-06-03T14:15:49.666Z",
-			"attachment_url": "https://i.imgur.com/jgZMupJ.jpeg",
-			"meta": {
-				"x": 200,
-				"y": 200,
-				"z": 164
-			}
-		},
-		"uuid": "Image.9.2"
-	},
-]
-
 export var demoCurrentImage: TaggedImage | undefined = demoImages[0];
 export function setCurrentImage(image: TaggedImage) {
 	demoCurrentImage = image;
@@ -119,17 +79,6 @@ export function demoToggleRotation(): void { currentRotation = (currentRotation 
 // placeholder for crop current photo
 export function demoToggleCrop(): void { info(t("Sorry, demo account does not support crop photos")) }
 
-// check if the `demoImages` is updated. 
-export var prevImages = cloneDeep(demoImages);
-export function checkUpdate() {
-	if (prevImages.length != demoImages.length) {
-		prevImages = cloneDeep(demoImages);
-		return true;
-	} else {
-		return false;
-	}
-}
-
 export const demoRenderLabel = (value: number) => {
 	if (value == demoImages.length - 1) { return t("newest"); }
 	if (value == 0) { return t("oldest"); }
@@ -140,13 +89,44 @@ export const demoGetImageIndex = (image: TaggedImage | undefined): number => {
 	else { return 0 }
 }
 
+/** Compare Logic */
 // flag to check if comparing photos
 export var isComparing: boolean = false
+export var compareList: TaggedImage[] = [];
+function getCompareList(): TaggedImage[] {
+	const currentX: number = demoCurrentImage?.body.meta.x || -1;
+	const currentY: number = demoCurrentImage?.body.meta.y || -1;
+	return demoImages.filter((image) =>
+		(image.body.meta.x == currentX) && (image.body.meta.y == currentY))
+}
+// Function to swith between normal mode and comparing mode. 
 export function demoCompare() {
 	if (isComparing) {
 		info(t("Comparing mode exited"));
+		isComparing = false;
 	} else {
-		info(t("Comparing photos, click again to exit comparing mode"));
+		compareList = getCompareList();
+		if (compareList.length > 1) {
+			isComparing = true;
+			info(t("Comparing photos, click again to exit comparing mode"));
+		} else {
+			info(t("No photo to compare for current image"));
+		}
 	}
-	isComparing = !isComparing;
+}
+
+// check if the state is updated. 
+export var prevImages = cloneDeep(demoImages);
+var prevMode = isComparing;
+export function checkUpdate() {
+	if (prevMode != isComparing) {
+		prevMode = isComparing;
+		return true;
+	}
+	if (prevImages.length != demoImages.length) {
+		prevImages = cloneDeep(demoImages);
+		return true;
+	} else {
+		return false;
+	}
 }

--- a/frontend/demo/demo_support_framework/supports.ts
+++ b/frontend/demo/demo_support_framework/supports.ts
@@ -8,6 +8,7 @@ import {
 	Xyz,
 } from "farmbot";
 import cloneDeep from 'lodash/cloneDeep';
+import { demoPhotos } from "./demo_photos";
 
 // a sample webcam feed for demo
 export const demoWebcamFeed: TaggedWebcamFeed = {
@@ -34,7 +35,11 @@ export const map_limit = {
 	z: 400,
 };
 
-export const demoImages: TaggedImage[] = [
+// a sample of images for demo
+export var demoImages: TaggedImage[] = demoPhotos;
+
+// place holder for compare Images
+export var compareImages: TaggedImage[] = [
 	{
 		"kind": "Image",
 		"specialStatus": SpecialStatus.SAVED,
@@ -57,147 +62,24 @@ export const demoImages: TaggedImage[] = [
 		"kind": "Image",
 		"specialStatus": SpecialStatus.SAVED,
 		"body": {
-			"id": 2,
+			"id": 10,
 			"device_id": 8,
-			"attachment_processed_at": "2017-06-02T14:16:45.899Z",
-			"updated_at": "2017-06-02T14:16:45.903Z",
-			"created_at": "2017-06-02T14:14:22.747Z",
-			"attachment_url": "https://i.imgur.com/EVo6XOU.jpeg",
-			"meta": {
-				"x": 200,
-				"y": 600,
-				"z": 164
-			}
-		},
-		"uuid": "Image.8.4"
-	},
-	{
-		"kind": "Image",
-		"specialStatus": SpecialStatus.SAVED,
-		"body": {
-			"id": 3,
-			"device_id": 8,
-			"attachment_processed_at": "2017-06-01T14:16:34.839Z",
-			"updated_at": "2017-06-01T14:16:34.984Z",
-			"created_at": "2017-06-01T14:14:22.726Z",
-			"attachment_url": "https://i.imgur.com/WsqcMr3.jpeg",
-			"meta": {
-				"x": 200,
-				"y": 1000,
-				"z": 53
-			}
-		},
-		"uuid": "Image.7.5"
-	},
-	{
-		"kind": "Image",
-		"specialStatus": SpecialStatus.SAVED,
-		"body": {
-			"id": 4,
-			"device_id": 8,
-			"attachment_processed_at": "2017-05-28T14:16:55.709Z",
-			"updated_at": "2017-05-28T14:16:55.715Z",
-			"created_at": "2017-05-28T14:15:50.666Z",
-			"attachment_url": "https://i.imgur.com/EudVDLU.jpeg",
-			"meta": {
-				"x": 600,
-				"y": 200,
-				"z": 164
-			}
-		},
-		"uuid": "Image.6.9"
-	},
-	{
-		"kind": "Image",
-		"specialStatus": SpecialStatus.SAVED,
-		"body": {
-			"id": 5,
-			"device_id": 8,
-			"attachment_processed_at": "2017-05-27T14:16:55.709Z",
-			"updated_at": "2017-05-27T14:16:55.715Z",
-			"created_at": "2017-05-27T14:15:50.666Z",
-			"attachment_url": "https://i.imgur.com/Xou4Ubz.jpeg",
-			"meta": {
-				"x": 600,
-				"y": 600,
-				"z": 164
-			}
-		},
-		"uuid": "Image.6.8"
-	},
-	{
-		"kind": "Image",
-		"specialStatus": SpecialStatus.SAVED,
-		"body": {
-			"id": 6,
-			"device_id": 8,
-			"attachment_processed_at": "2017-05-26T14:16:55.709Z",
-			"updated_at": "2017-05-26T14:16:55.715Z",
-			"created_at": "2017-05-26T14:15:50.666Z",
-			"attachment_url": "https://i.imgur.com/kAmrAZy.jpeg",
-			"meta": {
-				"x": 600,
-				"y": 1000,
-				"z": 164
-			}
-		},
-		"uuid": "Image.6.7"
-	},
-	{
-		"kind": "Image",
-		"specialStatus": SpecialStatus.SAVED,
-		"body": {
-			"id": 7,
-			"device_id": 8,
-			"attachment_processed_at": "2017-05-25T14:16:55.709Z",
-			"updated_at": "2017-05-25T14:16:55.715Z",
-			"created_at": "2017-05-25T14:15:50.666Z",
-			"attachment_url": "https://i.imgur.com/emxArQX.jpeg",
-			"meta": {
-				"x": 1000,
-				"y": 200,
-				"z": 164
-			}
-		},
-		"uuid": "Image.6.6"
-	},
-	{
-		"kind": "Image",
-		"specialStatus": SpecialStatus.SAVED,
-		"body": {
-			"id": 8,
-			"device_id": 8,
-			"attachment_processed_at": "2017-05-21T14:16:55.709Z",
-			"updated_at": "2017-05-21T14:16:55.715Z",
-			"created_at": "2017-05-21T14:15:50.666Z",
-			"attachment_url": "https://i.imgur.com/U3mBYpG.jpeg",
-			"meta": {
-				"x": 1000,
-				"y": 600,
-				"z": 164
-			}
-		},
-		"uuid": "Image.6.5"
-	},
-	{
-		"kind": "Image",
-		"specialStatus": SpecialStatus.SAVED,
-		"body": {
-			"id": 9,
-			"device_id": 8,
-			"attachment_processed_at": "2017-05-20T14:16:55.709Z",
-			"updated_at": "2017-05-20T14:16:55.715Z",
-			"created_at": "2017-05-20T14:15:50.666Z",
+			"attachment_processed_at": "2017-06-03T14:16:54.709Z",
+			"updated_at": "2017-06-03T14:16:54.715Z",
+			"created_at": "2017-06-03T14:15:49.666Z",
 			"attachment_url": "https://i.imgur.com/jgZMupJ.jpeg",
 			"meta": {
-				"x": 1000,
-				"y": 1000,
+				"x": 200,
+				"y": 200,
 				"z": 164
 			}
 		},
-		"uuid": "Image.6.4"
+		"uuid": "Image.9.2"
 	},
-];
+]
+
+// flag to check if comparing photos
+export var isComparing: boolean = false
 
 export var demoCurrentImage: TaggedImage | undefined = demoImages[0];
 export function setCurrentImage(image: TaggedImage) {

--- a/frontend/demo/demo_support_framework/supports.ts
+++ b/frontend/demo/demo_support_framework/supports.ts
@@ -78,9 +78,6 @@ export var compareImages: TaggedImage[] = [
 	},
 ]
 
-// flag to check if comparing photos
-export var isComparing: boolean = false
-
 export var demoCurrentImage: TaggedImage | undefined = demoImages[0];
 export function setCurrentImage(image: TaggedImage) {
 	demoCurrentImage = image;
@@ -141,4 +138,15 @@ export const demoRenderLabel = (value: number) => {
 export const demoGetImageIndex = (image: TaggedImage | undefined): number => {
 	if (image) { return demoImages.length - 1 - demoImages.indexOf(image) }
 	else { return 0 }
+}
+
+// flag to check if comparing photos
+export var isComparing: boolean = false
+export function demoCompare() {
+	if (isComparing) {
+		info(t("Comparing mode exited"));
+	} else {
+		info(t("Comparing photos, click again to exit comparing mode"));
+	}
+	isComparing = !isComparing;
 }

--- a/frontend/photos/images/image_flipper.tsx
+++ b/frontend/photos/images/image_flipper.tsx
@@ -8,7 +8,7 @@ import { FlipperImage } from "./flipper_image";
 import { selectImage, setShownMapImages } from "./actions";
 import { TaggedImage } from "farmbot";
 import { UUID } from "../../resources/interfaces";
-import { demoImages, demoCurrentImage, setCurrentImage, checkUpdate, compareImages, isComparing } from "../../demo/demo_support_framework/supports";
+import { demoImages, demoCurrentImage, setCurrentImage, checkUpdate, compareList, isComparing } from "../../demo/demo_support_framework/supports";
 
 export const PLACEHOLDER_FARMBOT = "/placeholder_farmbot.jpg";
 export const PLACEHOLDER_FARMBOT_DARK = "/placeholder_farmbot_dark.jpg";
@@ -59,7 +59,7 @@ export class ImageFlipper extends
 
   go = (increment: -1 | 1) => () => {
 		if (forceOnline() && demoCurrentImage) {
-			const images = isComparing ? compareImages : demoImages; 
+			const images = isComparing ? compareList : demoImages; 
 			const currentImage = demoCurrentImage; 
       const nextIndex = images.indexOf(currentImage) + increment; 
 	    const indexAfterNext = images.indexOf(currentImage) + 2 * increment; 
@@ -93,7 +93,7 @@ export class ImageFlipper extends
 
   render() {
 	  var { images, currentImage } = forceOnline() ? {images: demoImages, currentImage: demoCurrentImage}: this.props; 
-		if (isComparing) { images = compareImages }
+		if (isComparing) { images = compareList }
     const multipleImages = images.length > 1;
     const dark = this.props.id === "fullscreen-flipper";
 		if (checkUpdate()) {
@@ -103,12 +103,7 @@ export class ImageFlipper extends
 					disablePrev: i === 0, 
 					disableNext: i === images.length - 1
 				})
-		  } else {
-				this.setState({
-					disablePrev: false, 
-					disableNext: false
-				})
-			}
+		  }
 		}
     return <div className={`image-flipper ${this.props.id}`} id={this.props.id}
       onKeyDown={e => {

--- a/frontend/photos/images/image_flipper.tsx
+++ b/frontend/photos/images/image_flipper.tsx
@@ -8,7 +8,7 @@ import { FlipperImage } from "./flipper_image";
 import { selectImage, setShownMapImages } from "./actions";
 import { TaggedImage } from "farmbot";
 import { UUID } from "../../resources/interfaces";
-import { demoImages, demoCurrentImage, setCurrentImage, checkUpdate } from "../../demo/demo_support_framework/supports";
+import { demoImages, demoCurrentImage, setCurrentImage, checkUpdate, compareImages, isComparing } from "../../demo/demo_support_framework/supports";
 
 export const PLACEHOLDER_FARMBOT = "/placeholder_farmbot.jpg";
 export const PLACEHOLDER_FARMBOT_DARK = "/placeholder_farmbot_dark.jpg";
@@ -59,13 +59,15 @@ export class ImageFlipper extends
 
   go = (increment: -1 | 1) => () => {
 		if (forceOnline() && demoCurrentImage) {
-      const nextIndex = demoImages.indexOf(demoCurrentImage) + increment; 
-	    const indexAfterNext = demoImages.indexOf(demoCurrentImage) + 2 * increment; 
-	    const tooHigh = (index: number): boolean => index > demoImages.length - 1;
+			const images = isComparing ? compareImages : demoImages; 
+			const currentImage = demoCurrentImage; 
+      const nextIndex = images.indexOf(currentImage) + increment; 
+	    const indexAfterNext = images.indexOf(currentImage) + 2 * increment; 
+	    const tooHigh = (index: number): boolean => index > images.length - 1;
       const tooLow = (index: number): boolean => index < 0;
 
 	    if (!tooHigh(nextIndex) && !tooLow(nextIndex)) {
-				setCurrentImage(demoImages[nextIndex]); 
+				setCurrentImage(images[nextIndex]); 
 		    this.setState({
 			    disableNext: tooHigh(indexAfterNext),
 			    disablePrev: tooLow(indexAfterNext),
@@ -90,15 +92,15 @@ export class ImageFlipper extends
   };
 
   render() {
-	  const { images, currentImage } = forceOnline() ? {images: demoImages, currentImage: demoCurrentImage}: this.props; 
+	  const { images, currentImage } = forceOnline() ? {images: compareImages, currentImage: demoCurrentImage}: this.props; 
     const multipleImages = images.length > 1;
     const dark = this.props.id === "fullscreen-flipper";
 		if (checkUpdate()) {
-			if (demoCurrentImage) {
-				const i = demoImages.indexOf(demoCurrentImage); 
+			if (currentImage) {
+				const i = images.indexOf(currentImage); 
 				this.setState({
 					disablePrev: i === 0, 
-					disableNext: i === demoImages.length - 1
+					disableNext: i === images.length - 1
 				})
 		  } else {
 				this.setState({

--- a/frontend/photos/images/image_flipper.tsx
+++ b/frontend/photos/images/image_flipper.tsx
@@ -92,7 +92,8 @@ export class ImageFlipper extends
   };
 
   render() {
-	  const { images, currentImage } = forceOnline() ? {images: compareImages, currentImage: demoCurrentImage}: this.props; 
+	  var { images, currentImage } = forceOnline() ? {images: demoImages, currentImage: demoCurrentImage}: this.props; 
+		if (isComparing) { images = compareImages }
     const multipleImages = images.length > 1;
     const dark = this.props.id === "fullscreen-flipper";
 		if (checkUpdate()) {

--- a/frontend/photos/images/image_show_menu.tsx
+++ b/frontend/photos/images/image_show_menu.tsx
@@ -7,9 +7,10 @@ import {
   FlagDisplayRowProps, ImageFilterProps, ImageShowProps,
 } from "./interfaces";
 import { getImageTypeLabel } from "../photo_filter_settings/util";
+import { forceOnline } from "../../devices/must_be_online";
 
 export const ImageShowMenuTarget = (props: ImageFilterProps) => {
-  const shownInMap = every(Object.values(props.flags));
+  const shownInMap = every(Object.values(props.flags)) || forceOnline();
   return <i
     className={shownInMap
       ? "fa fa-eye green"
@@ -41,7 +42,7 @@ const ShownInMapDetails = (props: ImageShowProps) => {
     <FlagDisplayRow flag={flags.layerOn}
       labelOk={t("Map photo layer on")}
       labelNo={t("Map photo layer off")} />
-    <FlagDisplayRow flag={flags.inRange}
+    <FlagDisplayRow flag={flags.inRange || forceOnline()}
       title={image?.body.created_at}
       labelOk={t("Within filter range")}
       labelNo={t("Outside of filter range")} />
@@ -78,7 +79,7 @@ const HideImage =
       <div className={"content"}>
         <button
           className={"fb-button yellow"}
-          disabled={!(flags.zMatch && flags.inRange)}
+          disabled={!(flags.zMatch && flags.inRange || forceOnline())}
           title={flags.notHidden ? t("hide") : t("show")}
           onClick={() => image?.body.id
             && dispatch(toggleHideImage(flags.notHidden, image.body.id))}>

--- a/frontend/photos/images/interfaces.ts
+++ b/frontend/photos/images/interfaces.ts
@@ -88,6 +88,7 @@ export interface PhotoButtonsProps {
 
 export interface NewPhotoButtonsProps {
 	takePhoto(): void;
+	compare?(): void;
 	imageJobs: JobProgress[];
 	env: UserEnv;
 	botToMqttStatus: NetworkState;

--- a/frontend/photos/images/photos.tsx
+++ b/frontend/photos/images/photos.tsx
@@ -254,7 +254,7 @@ export class Photos extends React.Component<PhotosProps, PhotosComponentState> {
           canTransform={this.canTransform}
           canCrop={this.canCrop} />
       </PhotoFooter>
-      {forceOnline() 
+      {forceOnline() && isComparing
 			  ? demoImages.length > 1 && 
 			  <MarkedSlider 
 				  min={0}

--- a/frontend/photos/images/photos.tsx
+++ b/frontend/photos/images/photos.tsx
@@ -30,7 +30,8 @@ import {
 } from "../../farm_designer/move_to";
 import { forceOnline } from "../../devices/must_be_online";
 import { 
-	demoTakePhoto, demoDeletePhoto, demoToggleRotation, currentRotation, demoCurrentImage, demoToggleCrop
+	demoTakePhoto, demoDeletePhoto, demoToggleRotation, currentRotation, 
+	demoCurrentImage, demoToggleCrop, demoRenderLabel, demoGetImageIndex, demoImages
 } from "../../demo/demo_support_framework/supports";
 
 const NewPhotoButtons = (props: NewPhotoButtonsProps) => {
@@ -178,7 +179,7 @@ export class Photos extends React.Component<PhotosProps, PhotosComponentState> {
       env={this.props.env}
       crop={this.state.crop}
       images={this.props.images} 
-			rotation={currentRotation}/>;
+			rotation={forceOnline() ? currentRotation : undefined}/>;
 
   get highestIndex() { return this.props.images.length - 1; }
 
@@ -242,7 +243,18 @@ export class Photos extends React.Component<PhotosProps, PhotosComponentState> {
           canTransform={this.canTransform}
           canCrop={this.canCrop} />
       </PhotoFooter>
-      {this.props.images.length > 1 &&
+      {forceOnline() 
+			  ? demoImages.length > 1 && 
+			  <MarkedSlider 
+				  min={0}
+					max={demoImages.length-1}
+					labelStepSize={Math.max(demoImages.length, 2) - 1} 
+					labelRenderer={demoRenderLabel}
+					value={demoGetImageIndex(demoCurrentImage)}
+					onChange={this.onSliderChange}
+					items={demoImages}
+					itemValue={demoGetImageIndex} />
+				: this.props.images.length > 1 &&
         <MarkedSlider
           min={0}
           max={this.highestIndex}

--- a/frontend/photos/images/photos.tsx
+++ b/frontend/photos/images/photos.tsx
@@ -30,8 +30,8 @@ import {
 } from "../../farm_designer/move_to";
 import { forceOnline } from "../../devices/must_be_online";
 import { 
-	demoTakePhoto, demoDeletePhoto, demoToggleRotation, currentRotation, 
-	demoCurrentImage, demoToggleCrop, demoRenderLabel, demoGetImageIndex, demoImages
+	demoTakePhoto, demoDeletePhoto, demoToggleRotation, currentRotation, demoImages, 
+	demoCurrentImage, demoToggleCrop, demoRenderLabel, demoGetImageIndex, isComparing, demoCompare
 } from "../../demo/demo_support_framework/supports";
 
 const NewPhotoButtons = (props: NewPhotoButtonsProps) => {
@@ -50,6 +50,16 @@ const NewPhotoButtons = (props: NewPhotoButtonsProps) => {
         onClick={camDisabled.click || props.takePhoto}>
         {t("Take Photo")}
       </button>
+			{forceOnline() 
+			 ? <button
+			      className={isComparing 
+							? `fb-button red ${camDisabled.class}`
+							: `fb-button green ${camDisabled.class}`}
+			      title={camDisabled.title}
+			      onClick={camDisabled.click || props.compare}>
+			      {isComparing ? t("Comparing") : t("Compare")}
+		    </button>
+			 : undefined }
     </MustBeOnline>
     <p>
       {imageUploadJobProgress &&
@@ -205,6 +215,7 @@ export class Photos extends React.Component<PhotosProps, PhotosComponentState> {
         takePhoto={() => forceOnline() 
 					? demoTakePhoto()
 					: takePhoto}
+				compare={() => demoCompare()}
         env={this.props.env}
         imageJobs={this.props.imageJobs} />
       <Overlay isOpen={this.state.fullscreen}


### PR DESCRIPTION
By clicking `COMPARE` button, the user can compare photos showing the growth of the plants. 

Steps: 
1. Add a button to trigger compare mode. (photos.tsx)
2. Collect photos that is showing the growth of plants. (support.ts)
3. Add a time slider showing plants at different stage. (photos.tsx)
4. re-render the `PHOTOS` panel and `flipper`. (photos.tsx, image_flipper.tsx)

Issue: 
Not integrated with take/delete photo actions.  