### PR TITLE
Prevent user from taking/deleting photos while comparing

### DIFF
--- a/frontend/demo/demo_support_framework/supports.ts
+++ b/frontend/demo/demo_support_framework/supports.ts
@@ -46,6 +46,10 @@ export function setCurrentImage(image: TaggedImage) {
 
 // take photo of current position of FarmBot. 
 export function demoTakePhoto(): void {
+	if (isComparing) {
+		info(t("Unable to take photos while comparing"));
+		return;
+	}
 	// get image of current position
 	const id: number = Math.floor(((demoPos.x || 0) + 150) / 400) * 3 + Math.floor(((demoPos.y || 0) + 100) / 400) + 1;
 	const image = demoImages[demoImages.indexOf(demoImages.filter(i => i.body.id === id)[0])]
@@ -58,6 +62,10 @@ export function demoTakePhoto(): void {
 
 // delete current photo in flipper
 export function demoDeletePhoto(): void {
+	if (isComparing) {
+		info(t("Unable to delete photos while comparing"));
+		return;
+	}
 	if (demoCurrentImage) {
 		// get the index of current image. 
 		const i: number = demoImages.indexOf(demoCurrentImage);
@@ -80,13 +88,15 @@ export function demoToggleRotation(): void { currentRotation = (currentRotation 
 // placeholder for crop current photo
 export function demoToggleCrop(): void { info(t("Sorry, demo account does not support crop photos")) }
 
+// render the time line label of photos in flipper
 export const demoRenderLabel = (value: number) => {
-	if (value == demoImages.length - 1) { return t("newest"); }
+	if (value == compareList.length - 1) { return t("newest"); }
 	if (value == 0) { return t("oldest"); }
 	return "";
 }
+// calculate the index of image in time line. 
 export const demoGetImageIndex = (image: TaggedImage | undefined): number => {
-	if (image) { return demoImages.length - 1 - demoImages.indexOf(image) }
+	if (image) { return compareList.length - 1 - compareList.indexOf(image) }
 	else { return 0 }
 }
 
@@ -109,14 +119,14 @@ export function demoCompare() {
 		compareList = getCompareList();
 		if (compareList.length > 1) {
 			isComparing = true;
-			info(t("Comparing photos, click again to exit comparing mode"));
+			info(t("In comparing mode, flip over photos to compare! Click again to exit."));
 		} else {
-			info(t("No photo to compare for current image"));
+			info(t("No photo to compare for current image. Take photo to compare!"));
 		}
 	}
 }
 
-// check if the state is updated. 
+// check if the state of 'image_flipper' is updated. 
 export var prevImages = cloneDeep(demoImages);
 var prevMode = isComparing;
 export function checkUpdate() {

--- a/frontend/photos/images/photos.tsx
+++ b/frontend/photos/images/photos.tsx
@@ -30,8 +30,8 @@ import {
 } from "../../farm_designer/move_to";
 import { forceOnline } from "../../devices/must_be_online";
 import { 
-	demoTakePhoto, demoDeletePhoto, demoToggleRotation, currentRotation, demoImages, 
-	demoCurrentImage, demoToggleCrop, demoRenderLabel, demoGetImageIndex, isComparing, demoCompare
+	demoTakePhoto, demoDeletePhoto, demoToggleRotation, currentRotation, demoCurrentImage, 
+	demoToggleCrop, demoRenderLabel, demoGetImageIndex, isComparing, demoCompare, compareList
 } from "../../demo/demo_support_framework/supports";
 
 const NewPhotoButtons = (props: NewPhotoButtonsProps) => {
@@ -255,15 +255,15 @@ export class Photos extends React.Component<PhotosProps, PhotosComponentState> {
           canCrop={this.canCrop} />
       </PhotoFooter>
       {forceOnline() && isComparing
-			  ? demoImages.length > 1 && 
+			  ? compareList.length > 1 && 
 			  <MarkedSlider 
 				  min={0}
-					max={demoImages.length-1}
-					labelStepSize={Math.max(demoImages.length, 2) - 1} 
+					max={compareList.length-1}
+					labelStepSize={Math.max(compareList.length, 2) - 1} 
 					labelRenderer={demoRenderLabel}
 					value={demoGetImageIndex(demoCurrentImage)}
 					onChange={this.onSliderChange}
-					items={demoImages}
+					items={compareList}
 					itemValue={demoGetImageIndex} />
 				: this.props.images.length > 1 &&
         <MarkedSlider


### PR DESCRIPTION
Add a gate in (demo) take/delete photo functions. If passed, operate as instructed, if not, output indicating message and exit the function. 