### PR TITLE
Added a take a tour guide button

### DIFF
--- a/frontend/css/navbar.scss
+++ b/frontend/css/navbar.scss
@@ -169,6 +169,7 @@ nav {
   .nav-coordinates,
   .jobs-button,
   .setup-button,
+  .tour-button,
   .connectivity-button {
     display: flex;
     position: relative;
@@ -215,6 +216,11 @@ nav {
     }
   }
   .setup-button {
+    display: inline-block;
+    margin-top: 1.5rem;
+  }
+
+  .tour-button {
     display: inline-block;
     margin-top: 1.5rem;
   }

--- a/frontend/nav/index.tsx
+++ b/frontend/nav/index.tsx
@@ -202,6 +202,12 @@ export class NavBar extends React.Component<NavBarProps, Partial<NavBarState>> {
       : <div style={{ display: "inline" }} />;
   };
 
+  TakeAGuidedTour = () => {
+    return <a className={"tour-button"} onClick={() => push(Path.tours())}>
+        Take A Guided Tour
+      </a>
+  };
+  
   JobsButton = () => {
     const sortedJobs = sortJobs(this.props.bot.hardware.jobs).active;
     const jobActive = sortedJobs.length > 0;
@@ -292,6 +298,7 @@ export class NavBar extends React.Component<NavBarProps, Partial<NavBarState>> {
                       <this.AccountMenu />
                       <this.EstopButton />
                       <this.ConnectionStatus />
+                      <this.TakeAGuidedTour />
                       <this.SetupButton />
                       <this.JobsButton />
                       <this.Coordinates />


### PR DESCRIPTION
Implemented US09, enhancing the tour guide by adding an additional tour guide button, making it a lot easier to navigate around using the tour guide, as a result knowing how to use the features of the FarmBot. Overall, improving the user experience. 
