### PR TITLE
Photos weed detection instance jiahao

### DIFF
--- a/frontend/weeds/weed_inventory_item.tsx
+++ b/frontend/weeds/weed_inventory_item.tsx
@@ -11,6 +11,8 @@ import { mapPointClickAction, selectPoint } from "../farm_designer/map/actions";
 import { round } from "lodash";
 import { edit, save, destroy } from "../api/crud";
 import { FilePath, Path } from "../internal_urls";
+import { forceOnline } from "../devices/must_be_online";
+import { info } from "../toast/toast";
 
 export interface WeedInventoryItemProps {
   tpp: TaggedWeedPointer;
@@ -19,6 +21,12 @@ export interface WeedInventoryItemProps {
   pending?: boolean;
   maxSize?: number;
 }
+
+const maybeNoop = () =>
+	forceOnline() &&
+	info(t("HarvestX"), {
+		title: t("HarvestX")
+	});
 
 export class WeedInventoryItem extends
   React.Component<WeedInventoryItemProps, {}> {
@@ -40,6 +48,8 @@ export class WeedInventoryItem extends
     };
 
     const click = () => {
+      maybeNoop();
+      if (this.props.pending) return;
       if (getMode() == Mode.boxSelect) {
         mapPointClickAction(dispatch, tpp.uuid)();
         toggle("leave");
@@ -72,6 +82,7 @@ export class WeedInventoryItem extends
       </span>
       {this.props.pending &&
         <button className={"fb-button green"} onClick={e => {
+          maybeNoop();
           e.stopPropagation();
           this.props.dispatch(edit(tpp, { plant_stage: "active" }));
           this.props.dispatch(save(tpp.uuid));
@@ -80,6 +91,7 @@ export class WeedInventoryItem extends
         </button>}
       {this.props.pending &&
         <button className={"fb-button red"} onClick={e => {
+          maybeNoop();
           e.stopPropagation();
           this.props.dispatch(destroy(tpp.uuid, true));
         }}>

--- a/frontend/weeds/weeds_inventory.tsx
+++ b/frontend/weeds/weeds_inventory.tsx
@@ -35,6 +35,8 @@ import { createGroup } from "../point_groups/actions";
 import { GroupInventoryItem } from "../point_groups/group_inventory_item";
 import { push } from "../history";
 import { Path } from "../internal_urls";
+import { weedPointersDemo } from "../photos/weed_detector/actions";
+import { forceOnline } from "../devices/must_be_online";
 
 export interface WeedsProps {
   weeds: TaggedWeedPointer[];
@@ -51,7 +53,7 @@ interface WeedsState extends SortOptions {
 }
 
 export const mapStateToProps = (props: Everything): WeedsProps => ({
-  weeds: selectAllWeedPointers(props.resources.index),
+  weeds: forceOnline() ? weedPointersDemo : selectAllWeedPointers(props.resources.index),
   dispatch: props.dispatch,
   hoveredPoint: props.resources.consumers.farm_designer.hoveredPoint,
   getConfigValue: getWebAppConfigValue(() => props),
@@ -125,7 +127,7 @@ export const WeedsSection = (props: WeedsSectionProps) => {
       </EmptyStateWrapper>}
       {props.items.length == 0 && !noWeeds &&
         <p className={"no-weeds"}>{t(props.emptyStateText)}</p>}
-      {props.items.map(p => <WeedInventoryItem
+      {props.items.map(p => <WeedInventoryItem // important
         key={p.uuid}
         tpp={p}
         maxSize={maxSize}

--- a/frontend/weeds/weeds_inventory.tsx
+++ b/frontend/weeds/weeds_inventory.tsx
@@ -37,6 +37,7 @@ import { push } from "../history";
 import { Path } from "../internal_urls";
 import { weedPointersDemo } from "../photos/weed_detector/actions";
 import { forceOnline } from "../devices/must_be_online";
+import { info } from "../toast/toast";
 
 export interface WeedsProps {
   weeds: TaggedWeedPointer[];
@@ -48,12 +49,18 @@ export interface WeedsProps {
   weedsPanelState: WeedsPanelState;
 }
 
+const maybeNoop = () =>
+	forceOnline() &&
+	info(t("HarvestX"), {
+		title: t("HarvestX")
+	});
+
 interface WeedsState extends SortOptions {
   searchTerm: string;
 }
 
 export const mapStateToProps = (props: Everything): WeedsProps => ({
-  weeds: forceOnline() ? weedPointersDemo : selectAllWeedPointers(props.resources.index),
+  weeds: forceOnline() ? selectAllWeedPointers(props.resources.index).concat(weedPointersDemo) : selectAllWeedPointers(props.resources.index),
   dispatch: props.dispatch,
   hoveredPoint: props.resources.consumers.farm_designer.hoveredPoint,
   getConfigValue: getWebAppConfigValue(() => props),
@@ -90,6 +97,7 @@ export const WeedsSection = (props: WeedsSectionProps) => {
       {props.category == "pending" && props.items.length > 0 && props.open &&
         <div className={"approval-buttons"}>
           <button className={"fb-button green"} onClick={e => {
+            maybeNoop();
             e.stopPropagation();
             props.items.map(weed => {
               props.dispatch(edit(weed, { plant_stage: "active" }));
@@ -99,6 +107,7 @@ export const WeedsSection = (props: WeedsSectionProps) => {
             <i className={"fa fa-check"} />{t("all")}
           </button>
           <button className={"fb-button red"} onClick={e => {
+            maybeNoop();
             e.stopPropagation();
             props.items.map(weed => props.dispatch(destroy(weed.uuid, true)));
           }}>


### PR DESCRIPTION
By overwriting the weeds prop, now the detected weeds can be seen in the weeds panel.
The weeds array came from the same array that garden map is referencing.